### PR TITLE
v0.1.3: Update eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/pixta-dev/eslint-config-pixta#readme",
   "dependencies": {
-    "eslint-config-airbnb-base": "^3.0.1"
+    "eslint-config-airbnb-base": "^5.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.13.1",
-    "eslint-plugin-import": "^1.8.1"
+    "eslint": "^3.1.1",
+    "eslint-plugin-import": "^1.11.1"
   }
 }


### PR DESCRIPTION
Update eslint-config-airbnb-base and ESLint to use ESLint v3.
http://eslint.org/blog/2016/07/eslint-v3.1.1-released
