### PR TITLE
Use `eslint-config-airbnb` instead of `eslint-config-airbnb-base`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   "extends": [
     "eslint:recommended",
-    "airbnb-base"
+    "airbnb"
   ],
   "rules": {
     "comma-dangle": ["error", "never"],

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   },
   "homepage": "https://github.com/pixta-dev/eslint-config-pixta#readme",
   "dependencies": {
-    "eslint-config-airbnb-base": "^3.0.1"
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-jsx-a11y": "^1.5.5",
+    "eslint-plugin-react": "^5.2.2"
   },
   "devDependencies": {
     "eslint": "^2.13.1",


### PR DESCRIPTION
To add rules about React.js, replace `eslint-config-airbnb-base` by `eslint-config-airbnb`.
## Links
- [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb)
- [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)
