### PR TITLE
Disable import/no-unresolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = {
   ],
   "rules": {
     "comma-dangle": ["error", "never"],
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "no-underscore-dangle": ["error", { "allowAfterThis": true }]
+    "import/no-unresolved": "off",
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   }
 };


### PR DESCRIPTION
As of today, SideCI can't load any NPM modules, so it says`Error - Unable to resolve path to module 'foo'. (import/no-unresolved)` every time it runs ESLint.
Disabling this rule won't cause any problems for us because our JS-build will fail when programs can't resolve NPM module paths.
